### PR TITLE
feat(api): implement agent management endpoints

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import agent_environment, rag, data_management
+from app.api.v1.endpoints import agent_environment, rag, data_management, agent
 
 api_router = APIRouter()
 api_router.include_router(rag.router, prefix="/rag", tags=["rag"])
 api_router.include_router(data_management.router, prefix="/rag/data", tags=["data-management"]) 
 api_router.include_router(agent_environment.router, prefix="/environment", tags=["agent-environment"])
+api_router.include_router(agent.router, prefix="/agent", tags=["agent"])

--- a/app/api/v1/endpoints/agent.py
+++ b/app/api/v1/endpoints/agent.py
@@ -1,0 +1,123 @@
+from fastapi import APIRouter, Depends, HTTPException
+from motor.motor_asyncio import AsyncIOMotorClient
+from app.db.mongodb import get_database
+from app.schemas.agent_studio import (
+    AgentConfig,
+    AgentResponse,
+    PaginatedAgentResponse,
+    AgentUpdatePayload
+)
+from app.core.config import settings
+from typing import List
+from bson import ObjectId
+
+router = APIRouter()
+
+@router.post("/", response_model=AgentResponse)
+async def create_agent(
+        config: AgentConfig,
+        db: AsyncIOMotorClient = Depends(get_database)
+    ):
+    try:
+        # Create a single document for the agent
+        document = config.model_dump()
+        result = await db[settings.MONGODB_DB_NAME][settings.MONGODB_COLLECTION_AGENT].insert_one(document)
+        
+        return AgentResponse(
+            id=str(result.inserted_id),
+            name=document["name"],
+            environment=document["environment"],
+            system_prompt=document["system_prompt"],
+            description=document["description"]
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/", response_model=PaginatedAgentResponse)
+async def list_agents(
+        agent_id: str = None,
+        skip: int = 0,
+        limit: int = 10,
+        search: str = None,
+        db: AsyncIOMotorClient = Depends(get_database)
+    ):
+    try:
+        # Build query filters
+        query = {}
+        if agent_id:
+            query["_id"] = ObjectId(agent_id)
+        if search:
+            query["$or"] = [
+                {"name": {"$regex": search, "$options": "i"}},
+                {"description": {"$regex": search, "$options": "i"}}
+            ]
+
+        # Get total count
+        total = await db[settings.MONGODB_DB_NAME][settings.MONGODB_COLLECTION_AGENT].count_documents(query)
+
+        # Execute query with pagination
+        agents = await db[settings.MONGODB_DB_NAME][settings.MONGODB_COLLECTION_AGENT].find(query).skip(skip).limit(limit).to_list(length=None)
+        
+        return PaginatedAgentResponse(
+            total=total,
+            data=[
+                AgentResponse(
+                    id=str(agent["_id"]),
+                    name=agent["name"],
+                    environment=agent["environment"],
+                    system_prompt=agent["system_prompt"],
+                    description=agent["description"]
+                )
+                for agent in agents
+            ]
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.patch("/", response_model=AgentResponse)
+async def update_agent(
+        payload: AgentUpdatePayload,
+        db: AsyncIOMotorClient = Depends(get_database)
+    ):
+    try:
+        # Build update document based on provided fields
+        update_doc = {}
+        if payload.model_dump():
+            update_doc = payload.model_dump()
+        
+        if not update_doc:
+            raise HTTPException(status_code=400, detail="No update data provided")
+
+        result = await db[settings.MONGODB_DB_NAME][settings.MONGODB_COLLECTION_AGENT].find_one_and_update(
+            {"_id": ObjectId(payload.agent_id)},
+            {"$set": update_doc},
+            return_document=True
+        )
+        
+        if not result:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        
+        return AgentResponse(
+            id=str(result["_id"]),
+            name=result["name"],
+            environment=result["environment"],
+            system_prompt=result["system_prompt"],
+            description=result["description"]
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.delete("/{agent_id}", status_code=204)
+async def delete_agent(
+        agent_id: str,
+        db: AsyncIOMotorClient = Depends(get_database)
+    ):
+    try:
+        result = await db[settings.MONGODB_DB_NAME][settings.MONGODB_COLLECTION_AGENT].delete_one({"_id": ObjectId(agent_id)})
+        
+        if result.deleted_count == 0:
+            raise HTTPException(status_code=404, detail="Agent not found")
+            
+        return None
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import agent_environment, rag, data_management, whatsapp_msg
+from app.api.v1.endpoints import agent_environment, rag, data_management, whatsapp_msg, agent
 from app.core.config import settings
 from app.db.mongodb import connect_to_mongo, close_mongo_connection
 from fastapi.middleware.cors import CORSMiddleware
@@ -24,6 +24,7 @@ app.include_router(rag.router, prefix=f"{settings.API_V1_STR}/rag", tags=["rag"]
 app.include_router(data_management.router, prefix=f"{settings.API_V1_STR}/rag/data", tags=["data-management"])
 app.include_router(whatsapp_msg.router, prefix=f"{settings.API_V1_STR}/whatsapp", tags=["whatsapp"])
 app.include_router(agent_environment.router, prefix=f"{settings.API_V1_STR}/environment", tags=["agent-environment"])
+app.include_router(agent.router, prefix=f"{settings.API_V1_STR}/agent", tags=["agent"])
 
 @app.on_event("startup")
 async def startup_db_client():

--- a/app/schemas/agent_studio.py
+++ b/app/schemas/agent_studio.py
@@ -29,3 +29,27 @@ class EnvironmentUpdatePayload(BaseModel):
     features: Optional[List[dict]] = None
     tools: Optional[List[str]] = None
     llm_config: Optional[LLMConfig] = None
+
+class AgentConfig(BaseModel):
+    name: str
+    environment: str
+    system_prompt: str
+    description: Optional[str] = None
+
+class AgentResponse(BaseModel):
+    id: str
+    name: str
+    environment: str
+    system_prompt: str
+    description: Optional[str] = None
+
+class PaginatedAgentResponse(BaseModel):
+    total: int
+    data: List[AgentResponse]
+
+class AgentUpdatePayload(BaseModel):
+    agent_id: str
+    name: Optional[str] = None
+    environment: Optional[str] = None
+    system_prompt: Optional[str] = None
+    description: Optional[str] = None


### PR DESCRIPTION
- Create endpoints for managing agents: create, list, update, and delete
- Implement pagination and search functionality for agent listing
- Define schemas for agent configuration, response, and update payload
- Integrate MongoDB for persistent storage of agent data
- Ensure proper error handling and response formatting

Technical changes:
- New endpoints: POST, GET, PATCH, DELETE for /agent
- Added support for agent properties: name, environment, system prompt, and description
- Created PaginatedAgentResponse model for listing agents with total count

Resolves: #issue_number